### PR TITLE
Allow filter to throw Exception upon failing to get secretKey

### DIFF
--- a/src/main/java/com/acquia/http/HMACFilter.java
+++ b/src/main/java/com/acquia/http/HMACFilter.java
@@ -95,8 +95,8 @@ public abstract class HMACFilter implements Filter {
                 String secretKey = null;
                 try {
                     secretKey = getSecretKey(accessKey);
-                } catch(Exception skE) {
-                    String message = "Error: Fail to obtain the secret key from the server.";
+                } catch(SecretKeyException skE) {
+                    String message = "Error: " + skE.getMessage();
                     logger.error(message + "\n" + skE.getStackTrace());
                     wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
                     return;
@@ -187,8 +187,8 @@ public abstract class HMACFilter implements Filter {
      * 
      * @param accessKey
      * @return
-     * @throws Exception
+     * @throws SecretKeyException
      */
-    protected abstract String getSecretKey(String accessKey) throws Exception;
+    protected abstract String getSecretKey(String accessKey) throws SecretKeyException;
 
 }

--- a/src/main/java/com/acquia/http/HMACFilter.java
+++ b/src/main/java/com/acquia/http/HMACFilter.java
@@ -92,7 +92,15 @@ public abstract class HMACFilter implements Filter {
                 String nonce = authHeader.getNonce();
                 String signature = authHeader.getSignature();
 
-                String secretKey = getSecretKey(accessKey);
+                String secretKey = null;
+                try {
+                    secretKey = getSecretKey(accessKey);
+                } catch(Exception skE) {
+                    String message = "Error: Fail to obtain the secret key from the server.";
+                    logger.error(message + "\n" + skE.getStackTrace());
+                    wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
+                    return;
+                }
 
                 //check request validity
                 HMACMessageCreator messageCreator = new HMACMessageCreator();
@@ -174,12 +182,13 @@ public abstract class HMACFilter implements Filter {
         }
     }
 
-    /** 
+    /**
      * Returns the secret key for the given access key.
      * 
-     * @param accessKey Access Key
-     * @return Secret Key
+     * @param accessKey
+     * @return
+     * @throws Exception
      */
-    protected abstract String getSecretKey(String accessKey);
+    protected abstract String getSecretKey(String accessKey) throws Exception;
 
 }

--- a/src/main/java/com/acquia/http/HMACHttpRequestInterceptor.java
+++ b/src/main/java/com/acquia/http/HMACHttpRequestInterceptor.java
@@ -36,6 +36,9 @@ public class HMACHttpRequestInterceptor implements HttpRequestInterceptor {
     public static final String CONTEXT_AUTH_HEADER = "authHeader";
     public static final String CONTEXT_X_AUTHORIZATION_TIMESTAMP = "xAuthorizationTimestamp";
 
+    public static final String CONTEXT_SIGNABLE_REQUEST_MESSAGE = "signableRequestMessage";
+    public static final String CONTEXT_SIGNED_REQUEST_MESSAGE = "signedRequestMessage";
+
     public static final String VERSION = "2.0";
 
     /**
@@ -222,6 +225,9 @@ public class HMACHttpRequestInterceptor implements HttpRequestInterceptor {
         context.setAttribute(CONTEXT_AUTH_HEADER, authHeader);
         context.setAttribute(CONTEXT_X_AUTHORIZATION_TIMESTAMP, request.getFirstHeader(
             HMACMessageCreator.PARAMETER_X_AUTHORIZATION_TIMESTAMP).getValue()); //this header is guaranteed to exist
+
+        context.setAttribute(CONTEXT_SIGNABLE_REQUEST_MESSAGE, signableRequestMessage);
+        context.setAttribute(CONTEXT_SIGNED_REQUEST_MESSAGE, signedRequestMessage);
     }
 
     /**

--- a/src/main/java/com/acquia/http/HMACHttpResponseInterceptor.java
+++ b/src/main/java/com/acquia/http/HMACHttpResponseInterceptor.java
@@ -69,7 +69,14 @@ public class HMACHttpResponseInterceptor implements HttpResponseInterceptor {
                 StringBuffer statusBuffer = new StringBuffer("Error: Server failed to provide "
                         + HMACMessageCreator.PARAMETER_X_SERVER_AUTHORIZATION_HMAC_SHA256
                         + ", response validation header.");
-                statusBuffer.append("\nStatus Line: " + response.getStatusLine().toString());
+                statusBuffer.append("\n---- Interceptor Signable Request Message:\n").append(
+                    (String) context.getAttribute(
+                        HMACHttpRequestInterceptor.CONTEXT_SIGNABLE_REQUEST_MESSAGE));
+                statusBuffer.append("\n---- Interceptor Signed Request Message:\n").append(
+                    (String) context.getAttribute(
+                        HMACHttpRequestInterceptor.CONTEXT_SIGNED_REQUEST_MESSAGE));
+                statusBuffer.append("\n---- Server Response Status Line:\n").append(
+                    response.getStatusLine().toString());
 
                 String message = statusBuffer.toString();
                 logger.error(message);

--- a/src/main/java/com/acquia/http/HMACHttpServlet.java
+++ b/src/main/java/com/acquia/http/HMACHttpServlet.java
@@ -52,16 +52,19 @@ public abstract class HMACHttpServlet extends HttpServlet {
             CharResponseWrapper wrappedResponse = new CharResponseWrapper(httpResponse);
 
             //upon entry
-            this.validateRequestAuthorization(wrappedRequest, wrappedResponse);
+            boolean isAuthorized = this.validateRequestAuthorization(wrappedRequest,
+                wrappedResponse);
 
-            //reset input stream so it is ready to be consumed again
-            wrappedRequest.resetInputStream();
+            if (isAuthorized) {
+                //reset input stream so it is ready to be consumed again
+                wrappedRequest.resetInputStream();
 
-            //do service
-            super.service(wrappedRequest, wrappedResponse);
+                //do service
+                this.doHmacService(wrappedRequest, wrappedResponse);
 
-            //upon exit
-            this.appendServerResponseValidation(wrappedRequest, wrappedResponse, httpResponse);
+                //upon exit
+                this.appendServerResponseValidation(wrappedRequest, wrappedResponse, httpResponse);
+            }
         } else {
             super.service(request, response);
         }
@@ -69,12 +72,12 @@ public abstract class HMACHttpServlet extends HttpServlet {
 
     /**
      * Helper method to validate request authorization
-     * 
      * @param wrappedRequest
      * @param wrappedResponse
+     * @return true if signature is correct; false otherwise
      * @throws IOException
      */
-    private void validateRequestAuthorization(CharRequestWrapper wrappedRequest,
+    private boolean validateRequestAuthorization(CharRequestWrapper wrappedRequest,
             CharResponseWrapper wrappedResponse) throws IOException {
         //check timestamp
         String xAuthorizationTimestamp = wrappedRequest.getHeader(
@@ -86,18 +89,18 @@ public abstract class HMACHttpServlet extends HttpServlet {
                 String message = "Error: X-Authorization-Timestamp is too far in the future.";
                 logger.error(message);
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-                return;
+                return false;
             } else if (timestampStatus < 0) {
                 String message = "Error: X-Authorization-Timestamp is too far in the past.";
                 logger.error(message);
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-                return;
+                return false;
             }
         } else {
             String message = "Error: X-Authorization-Timestamp is required.";
             logger.error(message);
             wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-            return;
+            return false;
         }
 
         //check authorization
@@ -109,7 +112,7 @@ public abstract class HMACHttpServlet extends HttpServlet {
                 String message = "Error: Invalid authHeader; one or more required attributes are not set.";
                 logger.error(message);
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-                return;
+                return false;
             }
 
             String accessKey = authHeader.getId();
@@ -122,7 +125,7 @@ public abstract class HMACHttpServlet extends HttpServlet {
                 String message = "Error: " + skE.getMessage();
                 logger.error(message + "\n" + skE.getStackTrace());
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-                return;
+                return false;
             }
 
             //check request validity
@@ -145,14 +148,16 @@ public abstract class HMACHttpServlet extends HttpServlet {
                 String message = "Error: Invalid authentication token.";
                 logger.error(message);
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-                return;
+                return false;
             }
         } else {
             String message = "Error: Authorization is required.";
             logger.error(message);
             wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
-            return;
+            return false;
         }
+
+        return true;
     }
 
     /**
@@ -171,6 +176,19 @@ public abstract class HMACHttpServlet extends HttpServlet {
         } else {
             return 0;
         }
+    }
+
+    /**
+     * Call HttpServlet service method
+     * 
+     * @param wrappedRequest
+     * @param wrappedResponse
+     * @throws ServletException
+     * @throws IOException
+     */
+    protected void doHmacService(CharRequestWrapper wrappedRequest,
+            CharResponseWrapper wrappedResponse) throws ServletException, IOException {
+        super.service(wrappedRequest, wrappedResponse);
     }
 
     /**

--- a/src/main/java/com/acquia/http/HMACHttpServlet.java
+++ b/src/main/java/com/acquia/http/HMACHttpServlet.java
@@ -118,8 +118,8 @@ public abstract class HMACHttpServlet extends HttpServlet {
             String secretKey = null;
             try {
                 secretKey = getSecretKey(accessKey);
-            } catch(Exception skE) {
-                String message = "Error: Fail to obtain the secret key from the server.";
+            } catch(SecretKeyException skE) {
+                String message = "Error: " + skE.getMessage();
                 logger.error(message + "\n" + skE.getStackTrace());
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
                 return;
@@ -203,8 +203,8 @@ public abstract class HMACHttpServlet extends HttpServlet {
             String secretKey = null;
             try {
                 secretKey = getSecretKey(accessKey);
-            } catch(Exception skE) {
-                String message = "Error: Fail to obtain the secret key from the server.";
+            } catch(SecretKeyException skE) {
+                String message = "Error: " + skE.getMessage();
                 logger.error(message + "\n" + skE.getStackTrace());
                 wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
                 return;
@@ -240,8 +240,8 @@ public abstract class HMACHttpServlet extends HttpServlet {
      * 
      * @param accessKey
      * @return
-     * @throws Exception
+     * @throws SecretKeyException
      */
-    protected abstract String getSecretKey(String accessKey) throws Exception;
+    protected abstract String getSecretKey(String accessKey) throws SecretKeyException;
 
 }

--- a/src/main/java/com/acquia/http/HMACHttpServlet.java
+++ b/src/main/java/com/acquia/http/HMACHttpServlet.java
@@ -115,7 +115,15 @@ public abstract class HMACHttpServlet extends HttpServlet {
             String accessKey = authHeader.getId();
             String signature = authHeader.getSignature();
 
-            String secretKey = getSecretKey(accessKey);
+            String secretKey = null;
+            try {
+                secretKey = getSecretKey(accessKey);
+            } catch(Exception skE) {
+                String message = "Error: Fail to obtain the secret key from the server.";
+                logger.error(message + "\n" + skE.getStackTrace());
+                wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
+                return;
+            }
 
             //check request validity
             HMACMessageCreator messageCreator = new HMACMessageCreator();
@@ -192,7 +200,15 @@ public abstract class HMACHttpServlet extends HttpServlet {
             String accessKey = authHeader.getId();
             String nonce = authHeader.getNonce();
 
-            String secretKey = getSecretKey(accessKey);
+            String secretKey = null;
+            try {
+                secretKey = getSecretKey(accessKey);
+            } catch(Exception skE) {
+                String message = "Error: Fail to obtain the secret key from the server.";
+                logger.error(message + "\n" + skE.getStackTrace());
+                wrappedResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
+                return;
+            }
 
             //set response validation header
             HMACMessageCreator messageCreator = new HMACMessageCreator();
@@ -219,12 +235,13 @@ public abstract class HMACHttpServlet extends HttpServlet {
         }
     }
 
-    /** 
+    /**
      * Returns the secret key for the given access key.
      * 
-     * @param accessKey Access Key
-     * @return Secret Key
+     * @param accessKey
+     * @return
+     * @throws Exception
      */
-    protected abstract String getSecretKey(String accessKey);
+    protected abstract String getSecretKey(String accessKey) throws Exception;
 
 }

--- a/src/main/java/com/acquia/http/SecretKeyException.java
+++ b/src/main/java/com/acquia/http/SecretKeyException.java
@@ -1,0 +1,20 @@
+package com.acquia.http;
+
+/**
+ * Exception that is thrown when trying to get secret/private key given access/public key.
+ * 
+ * @author aric.tatan
+ *
+ */
+public class SecretKeyException extends Exception {
+
+    private static final long serialVersionUID = -8918809922281463624L;
+
+    public static final String NOT_FOUND = "No secret key is associated with the given access key.";
+    public static final String CANNOT_RETRIEVE = "Fail to obtain secret/private key from the authorization server.";
+
+    public SecretKeyException(String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/com/acquia/http/HMACHttpServletTest.java
+++ b/src/test/java/com/acquia/http/HMACHttpServletTest.java
@@ -1,5 +1,214 @@
 package com.acquia.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.acquia.http.CharResponseWrapper.ByteArrayServletStream;
+
 public class HMACHttpServletTest {
+
+    private final String id = "f0d16792-cdc9-4585-a5fd-bae3d898d8c5";
+    private final String secretKey = "eox4TsBBPhpi737yMxpdBbr3sgg/DEC4m47VXO0B8qJLsbdMsmN47j/ZF/EFpyUKtAhm0OWXMGaAjRaho7/93Q==";
+
+    private String reqBody = "{\"method\":\"hi.bob\",\"params\":[\"5\",\"4\",\"8\"]}";
+
+    private String respBody = "{\"person\":{\"id\":12007,\"engagementScore\":0,\"lastTouch\":\"2015-10-20T14:19:13Z\",\"firstTouch\":\"2015-10-20T14:19:13Z\",\"firstTimeVisitor\":true,\"subscriberStatus\":\"Unknown\",\"customerId\":10008,\"primaryIdentifier\":\"7RBYAsUXsXH6L5V871y0RO\",\"primaryIdentifierTypeId\":2,\"active\":true,\"lastModifiedDate\":\"2015-10-20T18:19:20Z\",\"anonymousVisitor\":false,\"doNotTrack\":false},\"identifiers\":[{\"id\":12611,\"identifier\":\"qa100\",\"personIdentifierTypeId\":6,\"personId\":12007,\"customerId\":10008,\"active\":true},{\"id\":12610,\"identifier\":\"qa100@example.com\",\"personIdentifierTypeId\":1,\"personId\":12007,\"customerId\":10008,\"active\":true},{\"id\":12609,\"identifier\":\"7RBYAsUXsXH6L5V871y0RO\",\"personIdentifierTypeId\":2,\"personId\":12007,\"customerId\":10008,\"active\":true}],\"touches\":[{\"id\":12212,\"touchDuration\":0,\"touchDurationInSeconds\":0,\"touchDate\":\"2015-10-20T14:19:13Z\",\"channelType\":\"twitter\",\"engagementScore\":0,\"referrer\":\"Direct\",\"referrerDomain\":\"Direct\",\"numberOfPageViews\":1,\"identifier\":\"33tpvFowlnHW7rNquqtmq5\",\"lastModifiedDate\":\"2015-10-20T18:19:20Z\",\"personId\":12007,\"customerId\":10008,\"personIdentifierId\":12609,\"events\":[{\"id\":17619,\"name\":\"Content View\",\"eventDate\":\"2015-10-20T14:19:13Z\",\"eventCategoryType\":\"OTHER\",\"accountId\":\"SOMEACCOUNTID\",\"referrer\":\"Direct\",\"captureIdentifier\":\"2zkT5TXrcC92HmKqMAq1Yc\",\"touchId\":12212,\"personId\":12007,\"customerId\":10008,\"eventCategoryId\":10046,\"clientDate\":\"2015-10-20T14:19:13Z\",\"clientTimezone\":\"America/Anguilla\",\"lastModifiedDate\":\"2015-10-20T18:19:20Z\"}]}]}";
+    private final String expectedServerAuthResponseSignature = "3uUNS0PW5+fl6x1ZCcHxnt0Me0PWvtNBGsH5F17P+h8=";
+
+    private HttpServletRequest request;
+    private ServletConfig servletConfig;
+
+    @Before
+    public void setup() throws IOException, ServletException {
+        //base Authorization parameter
+        String realm = "Plexus";
+
+        String nonce = "64d02132-40bf-4fce-85bf-3f1bb1bfe7dd";
+        String version = "2.0";
+        String xAuthorizationTimestamp = "1449578521";
+
+        String httpMethod = "POST";
+        //        String uri = "http://54.154.147.142:3000/register";
+        //        String secretKey = "eox4TsBBPhpi737yMxpdBbr3sgg/DEC4m47VXO0B8qJLsbdMsmN47j/ZF/EFpyUKtAhm0OWXMGaAjRaho7/93Q==";
+
+        String contentType = "application/json";
+        String xAuthorizationContentSha256 = "6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=";
+
+        String signature = "4VtBHjqrdDeYrJySoJVDUHpN9u3vyTsyOLz4chezi98=";
+
+        HMACAuthorizationHeader authHeader = new HMACAuthorizationHeader(realm, id, nonce,
+            version, /*headers*/
+            null, signature);
+
+        final ByteArrayInputStream realInputStream = new ByteArrayInputStream(reqBody.getBytes());
+        ServletInputStream requestInputStream = new ServletInputStream() {
+            @Override
+            public int read() {
+                return realInputStream.read();
+            }
+        };
+
+        this.request = mock(HttpServletRequest.class);
+        when(this.request.getHeader(HMACMessageCreator.PARAMETER_AUTHORIZATION)).thenReturn(
+            authHeader.toString());
+        when(this.request.getHeader(
+            HMACMessageCreator.PARAMETER_X_AUTHORIZATION_TIMESTAMP)).thenReturn(
+                xAuthorizationTimestamp);
+        when(this.request.getHeader(
+            HMACMessageCreator.PARAMETER_X_AUTHORIZATION_CONTENT_SHA256)).thenReturn(
+                xAuthorizationContentSha256);
+
+        when(this.request.getMethod()).thenReturn(httpMethod);
+        when(this.request.getHeader(HMACMessageCreator.PARAMETER_HOST)).thenReturn(
+            "54.154.147.142:3000");
+        when(this.request.getRequestURI()).thenReturn("/register");
+        when(this.request.getQueryString()).thenReturn("");
+
+        when(this.request.getContentLength()).thenReturn(
+            reqBody.getBytes(HMACMessageCreator.ENCODING_UTF_8).length);
+        when(this.request.getContentType()).thenReturn(contentType);
+        when(this.request.getInputStream()).thenReturn(requestInputStream);
+
+        this.servletConfig = mock(ServletConfig.class);
+        when(this.servletConfig.getInitParameter("algorithm")).thenReturn("SHA256");
+    }
+
+    @Test
+    public void testSuccessServlet() throws IOException, ServletException {
+        //prepare output stream
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ServletOutputStream sos = new ByteArrayServletStream(baos);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getOutputStream()).thenReturn(sos);
+
+        final StringBuilder serverResponseValidationHeader = new StringBuilder();
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                String headerKey = (String) args[0];
+                String valueKey = (String) args[1];
+                if (HMACMessageCreator.PARAMETER_X_SERVER_AUTHORIZATION_HMAC_SHA256.equals(
+                    headerKey)) {
+                    serverResponseValidationHeader.append(valueKey);
+                }
+                return null;
+            }
+        }).when(response).setHeader((String) anyObject(), (String) anyObject());
+
+        //test the servlet
+        @SuppressWarnings("serial")
+        class RestServerTest extends HMACHttpServlet {
+
+            @Override
+            protected String getSecretKey(String accessKey) throws SecretKeyException {
+                if (id.equals(accessKey)) {
+                    return secretKey;
+                }
+                return null;
+            }
+
+        }
+        RestServerTest servlet = new RestServerTest();
+        RestServerTest testServlet = spy(servlet);
+        doReturn(0).when(testServlet).compareTimestampWithinTolerance(anyLong());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) throws IOException {
+                HttpServletResponse response = invocation.getArgumentAt(1,
+                    HttpServletResponse.class);
+                response.getOutputStream().write(respBody.getBytes());
+                return null;
+            }
+        }).when(testServlet).doHmacService((CharRequestWrapper) anyObject(),
+            (CharResponseWrapper) anyObject());
+
+        testServlet.init(this.servletConfig);
+        testServlet.service(this.request, response);
+
+        assertEquals(this.expectedServerAuthResponseSignature,
+            serverResponseValidationHeader.toString());
+    }
+
+    @Test
+    public void testFailureServlet() throws IOException, ServletException {
+        //mock stuffs
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        //test the servlet
+        @SuppressWarnings("serial")
+        class RestServerTest extends HMACHttpServlet {
+
+            @Override
+            protected String getSecretKey(String accessKey) throws SecretKeyException {
+                if (id.equals(accessKey)) {
+                    return "other-key";
+                }
+                return null;
+            }
+
+        }
+        RestServerTest servlet = new RestServerTest();
+        RestServerTest testServlet = spy(servlet);
+        doReturn(0).when(testServlet).compareTimestampWithinTolerance(anyLong());
+
+        testServlet.init(this.servletConfig);
+        testServlet.service(this.request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_UNAUTHORIZED), (String) anyObject());
+        verify(testServlet, never()).doHmacService((CharRequestWrapper) anyObject(),
+            (CharResponseWrapper) anyObject());
+    }
+
+    @Test
+    public void testSecretKeyCannotRetrieve() throws IOException, ServletException {
+        //mock stuffs
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        //test the servlet
+        @SuppressWarnings("serial")
+        class RestServerTest extends HMACHttpServlet {
+
+            @Override
+            protected String getSecretKey(String accessKey) throws SecretKeyException {
+                throw new SecretKeyException(SecretKeyException.CANNOT_RETRIEVE);
+            }
+
+        }
+        RestServerTest servlet = new RestServerTest();
+        RestServerTest testServlet = spy(servlet);
+        doReturn(0).when(testServlet).compareTimestampWithinTolerance(anyLong());
+
+        testServlet.init(this.servletConfig);
+        testServlet.service(this.request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_UNAUTHORIZED),
+            eq("Error: " + SecretKeyException.CANNOT_RETRIEVE));
+        verify(testServlet, never()).doHmacService((CharRequestWrapper) anyObject(),
+            (CharResponseWrapper) anyObject());
+    }
 
 }


### PR DESCRIPTION
-) getSecretKey can now throw Exception
-) print out what was signed when unauthorized header occurred