### PR TITLE
Library is not signing the raw URL Query

### DIFF
--- a/src/main/java/com/acquia/http/HMACMessageCreator.java
+++ b/src/main/java/com/acquia/http/HMACMessageCreator.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,6 +66,7 @@ public class HMACMessageCreator {
         String host = request.getHeader(PARAMETER_HOST);
         String path = request.getRequestURI();
         String queryParameters = request.getQueryString();
+        logger.trace("Query string received: " + queryParameters);
         if (queryParameters == null) {
             queryParameters = "";
         }
@@ -142,7 +142,7 @@ public class HMACMessageCreator {
         try {
             URI uri = new URI(request.getRequestLine().getUri());
             path = uri.getPath();
-            queryParameters = uri.getQuery();
+            queryParameters = uri.getRawQuery();
             if (queryParameters == null) {
                 queryParameters = "";
             }
@@ -266,7 +266,7 @@ public class HMACMessageCreator {
         result.append(httpVerb.toUpperCase()).append("\n");
         result.append(host.toLowerCase()).append("\n");
         result.append(path).append("\n");
-        result.append(URLDecoder.decode(queryParameters, ENCODING_UTF_8)).append("\n");
+        result.append(queryParameters).append("\n");
 
         //adding Authorization header parameters
         result.append("id=").append(this.escapeProper(authHeader.getId()));


### PR DESCRIPTION
- Modified createSignableRequestMessage() to always retrieve the raw query string.
- Modified createSignableRequestMessage() to never encode the query parameters. Instead, use the raw value.